### PR TITLE
Dmx Player/Recorder の UI 調整

### DIFF
--- a/Assets/ArtNet/Editor/DmxRecorder/FileGeneratorDrawer.cs
+++ b/Assets/ArtNet/Editor/DmxRecorder/FileGeneratorDrawer.cs
@@ -8,12 +8,33 @@ namespace ArtNet.Editor.DmxRecorder
     [CustomPropertyDrawer(typeof(FileGenerator))]
     internal class FileGeneratorDrawer : TargetedPropertyDrawer<FileGenerator>
     {
-        private static class Styles
+        private static class Contents
         {
-            internal static readonly GUIContent FileNameLabel = new("File Name", "The name of the file to record to.");
-            internal static readonly GUIContent AddWildcardButton = new("+ Wildcards",
-                "Add a wildcard to the file name. Wildcards are replaced with values.");
-            internal static readonly GUIContent PathSelectButton = new("...", "Select the output location");
+            internal static readonly GUIContent FileNameLabel = new()
+            {
+                text = "File Name",
+                tooltip =
+                    "The name of the file to record to.\n" +
+                    "If using wildcards, they will be replaced with dynamic values. (use the \"+ Wildcards\" button)"
+            };
+
+            internal static readonly GUIContent AddWildcardButton = new()
+            {
+                text = "+ Wildcards",
+                tooltip = "Add a wildcard to the file name. Wildcards are replaced with values."
+            };
+
+            internal static readonly GUIContent PathSelectButton = new()
+            {
+                text = "...",
+                tooltip = "Select the output location"
+            };
+
+            internal static readonly GUIContent OpenDirectoryButton = new()
+            {
+                image = IconHelper.FolderOpen,
+                tooltip = "Open Directory"
+            };
         }
 
         private SerializedProperty _fileName;
@@ -28,12 +49,8 @@ namespace ArtNet.Editor.DmxRecorder
             clipping = TextClipping.Overflow
         };
 
-        private static Texture2D _openPathIcon;
-
         protected override void Initialize(SerializedProperty property)
         {
-            if (_openPathIcon == null) _openPathIcon = IconHelper.FolderOpen as Texture2D;
-
             base.Initialize(property);
 
             _fileName = property.FindPropertyRelative("_fileName");
@@ -48,9 +65,9 @@ namespace ArtNet.Editor.DmxRecorder
 
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.PropertyField(_fileName, Styles.FileNameLabel);
+                EditorGUILayout.PropertyField(_fileName, Contents.FileNameLabel);
 
-                if (GUILayout.Button(Styles.AddWildcardButton, EditorStyles.popup, GUILayout.Width(90)))
+                if (GUILayout.Button(Contents.AddWildcardButton, EditorStyles.popup, GUILayout.Width(90)))
                 {
                     GUI.FocusControl(null);
                     var menu = new GenericMenu();
@@ -87,7 +104,7 @@ namespace ArtNet.Editor.DmxRecorder
                 );
                 _directory.stringValue = EditorGUI.TextField(directoryInputRect, _directory.stringValue);
 
-                if (GUILayout.Button(Styles.PathSelectButton, EditorStyles.miniButton, GUILayout.Width(30)))
+                if (GUILayout.Button(Contents.PathSelectButton, EditorStyles.miniButton, GUILayout.Width(30)))
                 {
                     var outputDirectory = Target.OutputDirectory();
                     var newDirectory = EditorUtility.OpenFolderPanel("Select Folder", outputDirectory, "");
@@ -133,7 +150,7 @@ namespace ArtNet.Editor.DmxRecorder
                 var rect = GUILayoutUtility.GetRect(new GUIContent(outputPath), PathPreviewStyle, layoutOptions);
                 EditorGUI.SelectableLabel(rect, outputPath, PathPreviewStyle);
 
-                if (GUILayout.Button(_openPathIcon, EditorStyles.miniButton, GUILayout.Width(30)))
+                if (GUILayout.Button(Contents.OpenDirectoryButton, EditorStyles.miniButton, GUILayout.Width(30)))
                 {
                     var outputDir = Target.OutputDirectory();
                     var dir = new DirectoryInfo(outputDir);

--- a/Assets/ArtNet/Editor/DmxRecorder/PlayController.cs
+++ b/Assets/ArtNet/Editor/DmxRecorder/PlayController.cs
@@ -246,6 +246,7 @@ namespace ArtNet.Editor.DmxRecorder
 
             // TODO: O(n) なので DmxPackets の量が多い場合速度が遅くなるので最適化が必要
             var dmxPackets = DmxPackets.Where(x => x.time > prevSendTime && x.time <= newSendTime)
+                .OrderBy(x => x.time)
                 .Select(x => x.packet);
             foreach (var packet in dmxPackets)
             {

--- a/Assets/ArtNet/Editor/DmxRecorder/PlayerWindow.cs
+++ b/Assets/ArtNet/Editor/DmxRecorder/PlayerWindow.cs
@@ -69,7 +69,7 @@ namespace ArtNet.Editor.DmxRecorder
 
         private void CreateView()
         {
-            minSize = new Vector2(400, 200);
+            minSize = new Vector2(350, 400);
             var root = rootVisualElement;
 
             if (_visualTree == null)
@@ -200,7 +200,11 @@ namespace ArtNet.Editor.DmxRecorder
             _destinationList = new DestinationList
             {
                 name = "destinationList",
-                focusable = true
+                focusable = true,
+                style =
+                {
+                    flexGrow = 1
+                }
             };
             _destinationList.OnItemContextMenu += OnDestinationContextMenu;
             _destinationList.OnSelectionChanged += OnDestinationSelectionChanged;

--- a/Assets/ArtNet/Editor/DmxRecorder/PlayerWindow.uxml
+++ b/Assets/ArtNet/Editor/DmxRecorder/PlayerWindow.uxml
@@ -3,14 +3,14 @@
     <ui:VisualElement class="section-content">
         <ui:VisualElement>
             <ui:VisualElement style="width: 100%;">
-                <ui:TextField name="senderFileNameField" text="file_name" label="DMX File" />
+                <ui:TextField name="senderFileNameField" text="file_name" label="DMX File" tooltip="Play a DMX file" />
             </ui:VisualElement>
-            <ui:Button name="selectPlayFileButton" />
+            <ui:Button name="selectPlayFileButton" tooltip="Open a DMX file to play" />
         </ui:VisualElement>
     </ui:VisualElement>
     <ui:VisualElement class="section-content">
         <ui:VisualElement>
-            <ui:Button name="PlayButton" style="width: 45px; height: 45px;" />
+            <ui:Button name="PlayButton" tooltip="Play or pause the playback" style="width: 45px; height: 45px;" />
             <ui:Label name="playTimeLabel" text="0:00.000" />
             <ui:VisualElement style="width: 100%;">
                 <ui:Slider name="playSlider" high-value="100" focusable="false" />
@@ -27,9 +27,9 @@
             <ui:VisualElement class="section-content">
                 <ui:VisualElement>
                     <ui:VisualElement name="senderConfigFields" style="width: 100%;">
-                        <ui:Toggle label="Loop" name="sendLoopToggle" />
+                        <ui:Toggle label="Loop" name="sendLoopToggle" tooltip="Loop the playback" />
                         <ui:VisualElement style="flex-direction: row;">
-                            <ui:Label text="Speed" display-tooltip-when-elided="true" />
+                            <ui:Label text="Speed" display-tooltip-when-elided="true" tooltip="Playback speed" />
                             <ArtNet.Editor.DmxRecorder.SnapSlider name="sendSpeedSlider" style="flex-grow: 1;" />
                         </ui:VisualElement>
                     </ui:VisualElement>
@@ -41,7 +41,7 @@
         <ui:Label text="Send Destination" class="section-title" />
         <ui:VisualElement name="sendDestinationsPanel" class="Panel">
             <ui:VisualElement name="sendDestinationsListHeader">
-                <ui:Label text="+ Add" display-tooltip-when-elided="true" name="addDestinationLabel" style="height: 30px; -unity-text-align: middle-left; padding-left: 10px;" />
+                <ui:Label text="+ Add" display-tooltip-when-elided="true" name="addDestinationLabel" tooltip="Add a new send destination item to the list" style="height: 30px; -unity-text-align: middle-left; padding-left: 10px;" />
             </ui:VisualElement>
             <ui:VisualElement name="sendDestinationsList" />
         </ui:VisualElement>

--- a/Assets/ArtNet/Editor/DmxRecorder/PlayerWindow.uxml
+++ b/Assets/ArtNet/Editor/DmxRecorder/PlayerWindow.uxml
@@ -3,7 +3,7 @@
     <ui:VisualElement class="section-content">
         <ui:VisualElement>
             <ui:VisualElement style="width: 100%;">
-                <ui:TextField name="senderFileNameField" text="file_name" label="DMX File" tooltip="Play a DMX file" />
+                <ui:TextField name="senderFileNameField" text="file_name" label="DMX File" tooltip="Play a DMX file" readonly="true" />
             </ui:VisualElement>
             <ui:Button name="selectPlayFileButton" tooltip="Open a DMX file to play" />
         </ui:VisualElement>
@@ -37,13 +37,12 @@
             </ui:VisualElement>
         </ui:VisualElement>
     </ui:VisualElement>
-    <ui:VisualElement>
+    <ui:VisualElement style="flex-grow: 1;">
         <ui:Label text="Send Destination" class="section-title" />
         <ui:VisualElement name="sendDestinationsPanel" class="Panel">
             <ui:VisualElement name="sendDestinationsListHeader">
                 <ui:Label text="+ Add" display-tooltip-when-elided="true" name="addDestinationLabel" tooltip="Add a new send destination item to the list" style="height: 30px; -unity-text-align: middle-left; padding-left: 10px;" />
             </ui:VisualElement>
-            <ui:VisualElement name="sendDestinationsList" />
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/ArtNet/Editor/DmxRecorder/RecorderWindow.cs
+++ b/Assets/ArtNet/Editor/DmxRecorder/RecorderWindow.cs
@@ -17,6 +17,10 @@ namespace ArtNet.Editor.DmxRecorder
         {
             internal static readonly GUIContent DuplicateLabel = new("Duplicate");
             internal static readonly GUIContent DeleteLabel = new("Delete");
+
+            internal static string PlayButtonTooltip => "Start recording";
+            internal static string PauseButtonTooltip => "Pause recording";
+            internal static string StopButtonTooltip => "Stop recording";
         }
         #endregion
 
@@ -180,13 +184,15 @@ namespace ArtNet.Editor.DmxRecorder
             // TimeCode の作成
             _timeCode = visualElement.Q<Label>("timeCode");
 
-            _playButton = visualElement.Q<Button>("playButton");
+            _playButton = visualElement.Q<Button>("playButton")!;
             _playButton.clicked += OnPlayButtonClicked;
-            _playButton.style.backgroundImage = (StyleBackground) IconHelper.PlayButton;
+            _playButton.style!.backgroundImage = (StyleBackground) IconHelper.PlayButton;
+            _playButton.tooltip = Contents.PlayButtonTooltip;
 
-            _stopButton = visualElement.Q<Button>("stopButton");
+            _stopButton = visualElement.Q<Button>("stopButton")!;
             _stopButton.clicked += OnStopButtonClicked;
-            _stopButton.style.backgroundImage = (StyleBackground) IconHelper.PreMatQuad;
+            _stopButton.style!.backgroundImage = (StyleBackground) IconHelper.PreMatQuad;
+            _stopButton.tooltip = Contents.StopButtonTooltip;
             _stopButton.SetEnabled(false);
 
             // RecordersPanel の作成
@@ -289,7 +295,12 @@ namespace ArtNet.Editor.DmxRecorder
                         var recorderName = editor.target.GetType().Name;
                         EditorGUILayout.LabelField("Recorder Type", ObjectNames.NicifyVariableName(recorderName));
 
-                        if (GUILayout.Button(IconHelper.PresetIcon, new GUIStyle("iconButton") { fixedWidth = 20f }))
+                        var content = new GUIContent
+                        {
+                            tooltip = "Load or save a preset",
+                            image = IconHelper.PresetIcon
+                        };
+                        if (GUILayout.Button(content, new GUIStyle("iconButton") { fixedWidth = 20f }))
                         {
                             var settings = editor.target as RecorderSettings;
 
@@ -470,6 +481,7 @@ namespace ArtNet.Editor.DmxRecorder
             _timeCode.ClearClassList();
             _timeCode.AddToClassList("recording");
             _playButton.style.backgroundImage = (StyleBackground) IconHelper.PauseButton;
+            _playButton.tooltip = Contents.PauseButtonTooltip;
             _stopButton.SetEnabled(true);
             SetSettingPanelEnabled(false);
             _recorderList.Items.ForEach(x => x.SetReadOnly(true));
@@ -480,6 +492,7 @@ namespace ArtNet.Editor.DmxRecorder
             _timeCode.ClearClassList();
             _timeCode.AddToClassList("paused");
             _playButton.style.backgroundImage = (StyleBackground) IconHelper.PlayButton;
+            _playButton.tooltip = Contents.PlayButtonTooltip;
             _stopButton.SetEnabled(true);
         }
 
@@ -487,6 +500,7 @@ namespace ArtNet.Editor.DmxRecorder
         {
             _timeCode.ClearClassList();
             _playButton.style.backgroundImage = (StyleBackground) IconHelper.PlayButton;
+            _playButton.tooltip = Contents.PlayButtonTooltip;
             _stopButton.SetEnabled(false);
             _timeCode.text = TimeCodeText(_controller.GetRecordingTime());
             SetSettingPanelEnabled(true);

--- a/Assets/ArtNet/Editor/DmxRecorder/RecorderWindow.uxml
+++ b/Assets/ArtNet/Editor/DmxRecorder/RecorderWindow.uxml
@@ -3,14 +3,14 @@
     <ui:VisualElement class="Panel" style="min-height: 140px;">
         <ui:Label text="00:00:00.000" name="timeCode" />
         <ui:VisualElement name="controllerButton">
-            <ui:Button name="playButton" focusable="false" />
-            <ui:Button name="stopButton" focusable="false" />
+            <ui:Button name="playButton" focusable="false" tooltip="Start recording" />
+            <ui:Button name="stopButton" focusable="false" tooltip="Stop recording" />
         </ui:VisualElement>
     </ui:VisualElement>
     <ui:VisualElement style="flex-direction: row; flex-grow: 1;">
         <ui:VisualElement name="recordersPanel" class="Panel" style="width: 200px; max-width: 500px; min-width: 150px;">
             <ui:VisualElement class="RecorderListHeader">
-                <ui:Label text="+ Add" display-tooltip-when-elided="true" name="addRecorderLabel" style="height: 30px; -unity-text-align: middle-left; padding-left: 10px;" />
+                <ui:Label text="+ Add" display-tooltip-when-elided="true" name="addRecorderLabel" tooltip="Add a new recorder item to the list" style="height: 30px; -unity-text-align: middle-left; padding-left: 10px;" />
             </ui:VisualElement>
         </ui:VisualElement>
         <ui:ScrollView style="flex-grow: 1;">

--- a/Assets/ArtNet/Editor/DmxRecorder/SnapSlider.cs
+++ b/Assets/ArtNet/Editor/DmxRecorder/SnapSlider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using ArtNet.Editor.DmxRecorder.Util;
 using JetBrains.Annotations;
 using UnityEditor;
 using UnityEngine;
@@ -15,6 +16,8 @@ namespace ArtNet.Editor.DmxRecorder
 
         [NotNull] private readonly Slider _slider;
         [NotNull] private readonly Label _label;
+
+        public float DefaultValue { get; set; } = 1.0f;
 
         public float Value
         {
@@ -75,13 +78,12 @@ namespace ArtNet.Editor.DmxRecorder
                 Value += (evt!.delta.y > 0 ? step : -step);
             });
 
-            var resetButton = new Button(() => Value = 1) { text = "Reset" };
-            resetButton.RegisterCallback<MouseDownEvent>(evt =>
+            var resetButton = new Button(() => Value = DefaultValue)
             {
-                if (evt!.button != 1) return;
-
-                Value = 1;
-            });
+                name = "Reset value",
+                tooltip = $"Reset value to default ({DefaultValue:F2})"
+            };
+            resetButton.Add(new Image { image = IconHelper.RefreshIcon });
 
             style!.flexDirection = FlexDirection.Row;
             _slider.style!.flexGrow = 1.0f;

--- a/Assets/ArtNet/Editor/DmxRecorder/Util/IconHelper.cs
+++ b/Assets/ArtNet/Editor/DmxRecorder/Util/IconHelper.cs
@@ -16,6 +16,7 @@ namespace ArtNet.Editor.DmxRecorder.Util
         public static Texture PauseButton => Icon("PauseButton@2x", true);
         public static Texture FolderOpen => Icon("FolderOpened Icon");
         public static Texture PresetIcon => Icon("Preset.Context", true);
+        public static Texture RefreshIcon => Icon("Refresh", true);
 
         internal static Texture Icon(string iconPath, bool provideDarkModel = false)
         {


### PR DESCRIPTION
- Tooltip を追加
- Player で送信するパケットは時間で sort してから送るように変更
- Player の Speed Slider のリセットボタンをアイコンに変更
- Player の flexGrow 調整