### PR TITLE
refactor: ArtNet 受信処理のパフォーマンス改善 

### DIFF
--- a/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
+++ b/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using ArtNet.Enums;
-using ArtNet.IO;
 using ArtNet.Packets;
 using UnityEngine;
 using UnityEngine.Events;

--- a/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
+++ b/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
@@ -94,23 +94,30 @@ namespace ArtNet
 
         private void OnReceivedPacket(byte[] receiveBuffer, int length, EndPoint remoteEp)
         {
-            var packet = ArtNetPacket.Create(receiveBuffer);
-            if (packet == null) return;
+            var buffer = receiveBuffer.AsSpan(0, length);
+            if (!ArtNetPacket.TryGetOpCode(buffer, out var opCode)) return;
             LastReceivedAt = DateTime.Now;
 
-            switch (packet.OpCode)
+            switch (opCode)
             {
                 case OpCode.Dmx:
-                    _onReceivedDmxEvent?.Invoke(ReceivedData<DmxPacket>(packet, remoteEp));
+                    if (!DmxPacket.TryParse(buffer, out var dmxPacket)) return;
+                    _onReceivedDmxEvent?.Invoke(new ReceivedData<DmxPacket>(dmxPacket, remoteEp));
                     break;
                 case OpCode.Poll:
-                    _onReceivedPollEvent.Invoke(ReceivedData<PollPacket>(packet, remoteEp));
+                    var pollPacket = ArtNetPacket.FromByteArray<PollPacket>(buffer, false);
+                    if (pollPacket == null) return;
+                    _onReceivedPollEvent.Invoke(new ReceivedData<PollPacket>(pollPacket, remoteEp));
                     break;
                 case OpCode.PollReply:
-                    _onReceivedPollReplyEvent.Invoke(ReceivedData<PollReplyPacket>(packet, remoteEp));
+                    var pollReplyPacket = ArtNetPacket.FromByteArray<PollReplyPacket>(buffer, false);
+                    if (pollReplyPacket == null) return;
+                    _onReceivedPollReplyEvent.Invoke(new ReceivedData<PollReplyPacket>(pollReplyPacket, remoteEp));
                     break;
                 case OpCode.Sync:
-                    _onReceivedSyncEvent?.Invoke(ReceivedData<SyncPacket>(packet, remoteEp));
+                    var syncPacket = ArtNetPacket.FromByteArray<SyncPacket>(buffer, false);
+                    if (syncPacket == null) return;
+                    _onReceivedSyncEvent?.Invoke(new ReceivedData<SyncPacket>(syncPacket, remoteEp));
                     break;
                 case OpCode.TimeCode:
                     _onReceivedTimeCodeEvent?.Invoke(ReceivedData<TimeCodePacket>(packet, remoteEp));
@@ -133,12 +140,6 @@ namespace ArtNet
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-        }
-
-        private static ReceivedData<TPacket> ReceivedData<TPacket>(ArtNetPacket netPacket, EndPoint endPoint)
-            where TPacket : ArtNetPacket
-        {
-            return new ReceivedData<TPacket>(netPacket as TPacket, endPoint);
         }
     }
 }

--- a/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
+++ b/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
@@ -62,6 +62,7 @@ namespace ArtNet
         public const int ArtNetPort = 6454;
 
         [SerializeField] private bool _autoStart = true;
+        [SerializeField] private bool _invokeUnityEventWhenCSharpEventSubscribed;
         [SerializeField] private OnReceivedPollEvent _onReceivedPollEvent;
         [SerializeField] private OnReceivedPollReplyEvent _onReceivedPollReplyEvent;
         [SerializeField] private OnReceivedDmxEvent _onReceivedDmxEvent;
@@ -76,6 +77,16 @@ namespace ArtNet
         private UdpReceiver UdpReceiver { get; } = new(ArtNetPort);
         public DateTime LastReceivedAt { get; private set; }
         public bool IsConnected => LastReceivedAt.AddSeconds(1) > DateTime.Now;
+        public event Action<ReceivedData<PollPacket>> OnReceivedPoll;
+        public event Action<ReceivedData<PollReplyPacket>> OnReceivedPollReply;
+        public event Action<ReceivedData<DmxPacket>> OnReceivedDmx;
+        public event Action<ReceivedData<SyncPacket>> OnReceivedSync;
+        public event Action<ReceivedData<TimeCodePacket>> OnReceivedTimeCode;
+        public event Action<ReceivedData<AddressPacket>> OnReceivedAddress;
+        public event Action<ReceivedData<TodRequestPacket>> OnReceivedTodRequest;
+        public event Action<ReceivedData<TodDataPacket>> OnReceivedTodData;
+        public event Action<ReceivedData<TodControlPacket>> OnReceivedTodControl;
+        public event Action<ReceivedData<RdmPacket>> OnReceivedRdm;
 
         private void Awake()
         {
@@ -101,44 +112,71 @@ namespace ArtNet
             switch (opCode)
             {
                 case OpCode.Dmx:
-                    if (!DmxPacket.TryParse(buffer, out var dmxPacket)) return;
-                    _onReceivedDmxEvent?.Invoke(new ReceivedData<DmxPacket>(dmxPacket, remoteEp));
+                    DispatchDmx(buffer, remoteEp, OnReceivedDmx, _onReceivedDmxEvent);
                     break;
                 case OpCode.Poll:
-                    var pollPacket = ArtNetPacket.FromByteArray<PollPacket>(buffer, false);
-                    if (pollPacket == null) return;
-                    _onReceivedPollEvent.Invoke(new ReceivedData<PollPacket>(pollPacket, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedPoll, _onReceivedPollEvent);
                     break;
                 case OpCode.PollReply:
-                    var pollReplyPacket = ArtNetPacket.FromByteArray<PollReplyPacket>(buffer, false);
-                    if (pollReplyPacket == null) return;
-                    _onReceivedPollReplyEvent.Invoke(new ReceivedData<PollReplyPacket>(pollReplyPacket, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedPollReply, _onReceivedPollReplyEvent);
                     break;
                 case OpCode.Sync:
-                    var syncPacket = ArtNetPacket.FromByteArray<SyncPacket>(buffer, false);
-                    if (syncPacket == null) return;
-                    _onReceivedSyncEvent?.Invoke(new ReceivedData<SyncPacket>(syncPacket, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedSync, _onReceivedSyncEvent);
                     break;
                 case OpCode.TimeCode:
-                    _onReceivedTimeCodeEvent?.Invoke(ReceivedData<TimeCodePacket>(packet, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedTimeCode, _onReceivedTimeCodeEvent);
                     break;
                 case OpCode.Address:
-                    _onReceivedAddressEvent?.Invoke(ReceivedData<AddressPacket>(packet, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedAddress, _onReceivedAddressEvent);
                     break;
                 case OpCode.TodRequest:
-                    _onReceivedTodRequestEvent?.Invoke(ReceivedData<TodRequestPacket>(packet, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedTodRequest, _onReceivedTodRequestEvent);
                     break;
                 case OpCode.TodData:
-                    _onReceivedTodDataEvent?.Invoke(ReceivedData<TodDataPacket>(packet, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedTodData, _onReceivedTodDataEvent);
                     break;
                 case OpCode.TodControl:
-                    _onReceivedTodControlEvent?.Invoke(ReceivedData<TodControlPacket>(packet, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedTodControl, _onReceivedTodControlEvent);
                     break;
                 case OpCode.Rdm:
-                    _onReceivedRdmEvent?.Invoke(ReceivedData<RdmPacket>(packet, remoteEp));
+                    DispatchStandard(buffer, remoteEp, OnReceivedRdm, _onReceivedRdmEvent);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private void DispatchDmx(
+            ReadOnlySpan<byte> buffer,
+            EndPoint remoteEp,
+            Action<ReceivedData<DmxPacket>> cSharpHandler,
+            UnityEvent<ReceivedData<DmxPacket>> unityHandler)
+        {
+            if (!DmxPacket.TryParse(buffer, out var packet)) return;
+            Dispatch(new ReceivedData<DmxPacket>(packet, remoteEp), cSharpHandler, unityHandler);
+        }
+
+        private void DispatchStandard<TPacket>(
+            ReadOnlySpan<byte> buffer,
+            EndPoint remoteEp,
+            Action<ReceivedData<TPacket>> cSharpHandler,
+            UnityEvent<ReceivedData<TPacket>> unityHandler) where TPacket : ArtNetPacket, new()
+        {
+            var packet = ArtNetPacket.FromByteArray<TPacket>(buffer, false);
+            if (packet == null) return;
+            Dispatch(new ReceivedData<TPacket>(packet, remoteEp), cSharpHandler, unityHandler);
+        }
+
+        private void Dispatch<TPacket>(
+            ReceivedData<TPacket> receivedData,
+            Action<ReceivedData<TPacket>> cSharpHandler,
+            UnityEvent<ReceivedData<TPacket>> unityHandler) where TPacket : ArtNetPacket
+        {
+            var hasCSharpHandler = cSharpHandler != null;
+            cSharpHandler?.Invoke(receivedData);
+            if (_invokeUnityEventWhenCSharpEventSubscribed || !hasCSharpHandler)
+            {
+                unityHandler?.Invoke(receivedData);
             }
         }
     }

--- a/Assets/ArtNet/Runtime/Scripts/Core/IO/ArtNetReader.cs
+++ b/Assets/ArtNet/Runtime/Scripts/Core/IO/ArtNetReader.cs
@@ -45,6 +45,12 @@ namespace ArtNet.IO
             return value;
         }
 
+        internal void ReadBytesTo(byte[] destination, int length)
+        {
+            _data.Slice(_position, length).CopyTo(destination);
+            _position += length;
+        }
+
         internal string ReadString(int length)
         {
             var value = Encoding.ASCII.GetString(_data.Slice(_position, length));

--- a/Assets/ArtNet/Runtime/Scripts/Core/Packets/ArtNetPacket.cs
+++ b/Assets/ArtNet/Runtime/Scripts/Core/Packets/ArtNetPacket.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Text;
-using ArtNet.Common;
 using ArtNet.Enums;
 using ArtNet.IO;
 
@@ -95,9 +94,7 @@ namespace ArtNet.Packets
         /// <returns>An instance of the packet or null if the packet is not valid.</returns>
         public static ArtNetPacket Create(ReadOnlySpan<byte> buffer)
         {
-            var opCode = ArtNetOpCode(buffer);
-            if (opCode == null) return null;
-            if (Enum.IsDefined(typeof(OpCode), opCode) == false) return null;
+            if (!TryGetOpCode(buffer, out var opCode)) return null;
 
             return opCode switch
             {
@@ -113,6 +110,35 @@ namespace ArtNet.Packets
                 OpCode.TimeCode => FromByteArray<TimeCodePacket>(buffer, false),
                 _ => throw new ArgumentOutOfRangeException(nameof(opCode), opCode, "OpCode not supported")
             };
+        }
+
+        public static bool TryGetOpCode(ReadOnlySpan<byte> buffer, out OpCode opCode)
+        {
+            var parsedOpCode = ArtNetOpCode(buffer);
+            if (parsedOpCode == null)
+            {
+                opCode = default;
+                return false;
+            }
+
+            switch (parsedOpCode.Value)
+            {
+                case OpCode.Poll:
+                case OpCode.PollReply:
+                case OpCode.Dmx:
+                case OpCode.Sync:
+                case OpCode.Address:
+                case OpCode.TodRequest:
+                case OpCode.TodData:
+                case OpCode.TodControl:
+                case OpCode.Rdm:
+                case OpCode.TimeCode:
+                    opCode = parsedOpCode.Value;
+                    return true;
+                default:
+                    opCode = default;
+                    return false;
+            }
         }
 
         /// <summary>

--- a/Assets/ArtNet/Runtime/Scripts/Core/Packets/DmxPacket.cs
+++ b/Assets/ArtNet/Runtime/Scripts/Core/Packets/DmxPacket.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Buffers.Binary;
 using ArtNet.Enums;
 using ArtNet.IO;
 
@@ -5,6 +7,9 @@ namespace ArtNet.Packets
 {
     public class DmxPacket : ArtNetPacket
     {
+        private const int DmxHeaderOffset = 12;
+        private const int MinimumDmxPacketLength = 19;
+
         public override OpCode OpCode => OpCode.Dmx;
         protected override int MinimumBodyLength => 7;
 
@@ -15,6 +20,31 @@ namespace ArtNet.Packets
         public ushort Length => Dmx == null ? (ushort) 0 : (ushort) Dmx.Length;
 
         public byte[] Dmx { get; set; }
+
+        public static bool TryParse(ReadOnlySpan<byte> buffer, out DmxPacket packet)
+        {
+            packet = null;
+            if (buffer.Length < MinimumDmxPacketLength) return false;
+
+            var protocolVersion = BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(10, 2));
+            if (protocolVersion != ProtocolVersion) return false;
+
+            var sequence = buffer[DmxHeaderOffset];
+            var physical = buffer[DmxHeaderOffset + 1];
+            var universe = BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(DmxHeaderOffset + 2, 2));
+            var dmxLength = BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(DmxHeaderOffset + 4, 2));
+            if (512 < dmxLength) return false;
+            if (buffer.Length < DmxHeaderOffset + 6 + dmxLength) return false;
+
+            packet = new DmxPacket
+            {
+                Sequence = sequence,
+                Physical = physical,
+                Universe = universe,
+                Dmx = buffer.Slice(DmxHeaderOffset + 6, dmxLength).ToArray()
+            };
+            return true;
+        }
 
         protected override bool DeserializeBody(ArtNetReader artNetReader)
         {

--- a/Assets/ArtNet/Runtime/Scripts/Core/Packets/DmxPacket.cs
+++ b/Assets/ArtNet/Runtime/Scripts/Core/Packets/DmxPacket.cs
@@ -9,6 +9,8 @@ namespace ArtNet.Packets
     {
         private const int DmxHeaderOffset = 12;
         private const int MinimumDmxPacketLength = 19;
+        private readonly byte[] _dmxBuffer = new byte[512];
+        private int _dmxLength = -1;
 
         public override OpCode OpCode => OpCode.Dmx;
         protected override int MinimumBodyLength => 7;
@@ -17,9 +19,25 @@ namespace ArtNet.Packets
         public byte Physical { get; set; }
         public ushort Universe { get; set; }
 
-        public ushort Length => Dmx == null ? (ushort) 0 : (ushort) Dmx.Length;
+        public ushort Length => _dmxLength > 0 ? (ushort) _dmxLength : (ushort) 0;
+        public ReadOnlySpan<byte> DmxSpan => _dmxLength > 0 ? _dmxBuffer.AsSpan(0, Math.Min(_dmxLength, _dmxBuffer.Length)) : ReadOnlySpan<byte>.Empty;
 
-        public byte[] Dmx { get; set; }
+        public byte[] Dmx
+        {
+            get => _dmxLength < 0 ? null : DmxSpan.ToArray();
+            set
+            {
+                if (value == null)
+                {
+                    _dmxLength = -1;
+                    return;
+                }
+
+                _dmxLength = value.Length;
+                var copyLength = Math.Min(value.Length, _dmxBuffer.Length);
+                value.AsSpan(0, copyLength).CopyTo(_dmxBuffer);
+            }
+        }
 
         public static bool TryParse(ReadOnlySpan<byte> buffer, out DmxPacket packet)
         {
@@ -41,8 +59,9 @@ namespace ArtNet.Packets
                 Sequence = sequence,
                 Physical = physical,
                 Universe = universe,
-                Dmx = buffer.Slice(DmxHeaderOffset + 6, dmxLength).ToArray()
+                _dmxLength = dmxLength
             };
+            buffer.Slice(DmxHeaderOffset + 6, dmxLength).CopyTo(packet._dmxBuffer);
             return true;
         }
 
@@ -54,7 +73,8 @@ namespace ArtNet.Packets
             int length = artNetReader.ReadNetworkUInt16();
             if (length > 512) return false;
             if (artNetReader.RemainingLength < length) return false;
-            Dmx = artNetReader.ReadBytes(length);
+            artNetReader.ReadBytesTo(_dmxBuffer, length);
+            _dmxLength = length;
 
             return true;
         }
@@ -65,7 +85,7 @@ namespace ArtNet.Packets
             artNetWriter.Write(Physical);
             artNetWriter.Write(Universe);
             artNetWriter.WriteNetwork(Length);
-            artNetWriter.Write(Dmx);
+            artNetWriter.Write(_dmxBuffer, 0, _dmxLength);
         }
 
         protected override bool Validate()

--- a/Assets/ArtNet/Runtime/Scripts/Devices/DmxDeviceBase.cs
+++ b/Assets/ArtNet/Runtime/Scripts/Devices/DmxDeviceBase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using ArtNet.Common;
 using UnityEngine;
 
@@ -27,7 +26,7 @@ namespace ArtNet.Devices
         }
 
 
-        public void DmxUpdate(byte[] dmx)
+        public void DmxUpdate(ReadOnlySpan<byte> dmx)
         {
             if (dmx.Length < ChannelNumber)
             {
@@ -35,8 +34,8 @@ namespace ArtNet.Devices
                 return;
             }
 
-            if (dmx.SequenceEqual(DmxData)) return;
-            Buffer.BlockCopy(dmx, 0, DmxData, 0, ChannelNumber);
+            if (dmx.SequenceEqual(DmxData.AsSpan(0, ChannelNumber))) return;
+            dmx[..ChannelNumber].CopyTo(DmxData);
 
             UpdateProperties();
         }

--- a/Assets/ArtNet/Runtime/Scripts/Devices/IDmxDevice.cs
+++ b/Assets/ArtNet/Runtime/Scripts/Devices/IDmxDevice.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ArtNet.Devices
 {
     public interface IDmxDevice
@@ -5,6 +7,6 @@ namespace ArtNet.Devices
         byte ChannelNumber { get; }
         ushort Universe { get; }
         ushort StartAddress { get; }
-        void DmxUpdate(byte[] dmx);
+        void DmxUpdate(ReadOnlySpan<byte> dmx);
     }
 }

--- a/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
+++ b/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
@@ -10,7 +10,6 @@ namespace ArtNet
     public class DmxManager : MonoBehaviour
     {
         private readonly Queue<ushort> _updatedUniverses = new();
-        private readonly Dictionary<IDmxDevice, byte[]> _deviceDmxBufferCache = new();
         private Dictionary<ushort, byte[]> DmxDictionary { get; } = new();
         public Dictionary<ushort, IEnumerable<IDmxDevice>> DmxDevices { get; private set; }
 
@@ -26,10 +25,10 @@ namespace ArtNet
                     if (devices == null) continue;
                     foreach (var device in devices)
                     {
-                        // 毎フレームの配列生成を避け、デバイスごとに再利用して GC を抑える
-                        var deviceDmx = GetOrCreateDeviceDmxBuffer(device);
-                        Buffer.BlockCopy(dmx, device.StartAddress, deviceDmx, 0, device.ChannelNumber);
-                        device.DmxUpdate(deviceDmx);
+                        var startAddress = (int) device.StartAddress;
+                        var channelCount = (int) device.ChannelNumber;
+                        if (dmx.Length < startAddress + channelCount) continue;
+                        device.DmxUpdate(dmx.AsSpan(startAddress, channelCount));
                     }
                 }
             }
@@ -38,7 +37,6 @@ namespace ArtNet
         public void OnEnable()
         {
             DmxDevices = FindDmxDevices();
-            _deviceDmxBufferCache.Clear();
         }
 
         private static Dictionary<ushort, IEnumerable<IDmxDevice>> FindDmxDevices()
@@ -72,19 +70,5 @@ namespace ArtNet
             }
         }
 
-        private byte[] GetOrCreateDeviceDmxBuffer(IDmxDevice device)
-        {
-            if (_deviceDmxBufferCache.TryGetValue(device, out var buffer))
-            {
-                // デバイスのチャンネル数が変わった場合は新しいバッファを作る
-                if (buffer != null && buffer.Length == device.ChannelNumber) return buffer;
-                buffer = new byte[device.ChannelNumber];
-                _deviceDmxBufferCache[device] = buffer;
-                return buffer;
-            }
-            var newBuffer = new byte[device.ChannelNumber];
-            _deviceDmxBufferCache[device] = newBuffer;
-            return newBuffer;
-        }
     }
 }

--- a/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
+++ b/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
@@ -10,6 +10,7 @@ namespace ArtNet
     public class DmxManager : MonoBehaviour
     {
         private readonly Queue<ushort> _updatedUniverses = new();
+        private readonly Dictionary<IDmxDevice, byte[]> _deviceDmxBufferCache = new();
         private Dictionary<ushort, byte[]> DmxDictionary { get; } = new();
         public Dictionary<ushort, IEnumerable<IDmxDevice>> DmxDevices { get; private set; }
 
@@ -25,7 +26,8 @@ namespace ArtNet
                     if (devices == null) continue;
                     foreach (var device in devices)
                     {
-                        var deviceDmx = new byte[device.ChannelNumber];
+                        // 毎フレームの配列生成を避け、デバイスごとに再利用して GC を抑える
+                        var deviceDmx = GetOrCreateDeviceDmxBuffer(device);
                         Buffer.BlockCopy(dmx, device.StartAddress, deviceDmx, 0, device.ChannelNumber);
                         device.DmxUpdate(deviceDmx);
                     }
@@ -36,6 +38,7 @@ namespace ArtNet
         public void OnEnable()
         {
             DmxDevices = FindDmxDevices();
+            _deviceDmxBufferCache.Clear();
         }
 
         private static Dictionary<ushort, IEnumerable<IDmxDevice>> FindDmxDevices()
@@ -59,12 +62,29 @@ namespace ArtNet
             var packet = receivedData.Packet;
             var universe = packet.Universe;
             if (!DmxDictionary.ContainsKey(universe)) DmxDictionary.Add(universe, packet.Dmx);
-            Buffer.BlockCopy(packet.Dmx, 0, DmxDictionary[universe], 0, 512);
+            var targetBuffer = DmxDictionary[universe];
+            var copyLength = Math.Min(packet.Dmx.Length, targetBuffer.Length);
+            Buffer.BlockCopy(packet.Dmx, 0, targetBuffer, 0, copyLength);
             lock (_updatedUniverses)
             {
                 if (_updatedUniverses.Contains(universe)) return;
                 _updatedUniverses.Enqueue(universe);
             }
+        }
+
+        private byte[] GetOrCreateDeviceDmxBuffer(IDmxDevice device)
+        {
+            if (_deviceDmxBufferCache.TryGetValue(device, out var buffer))
+            {
+                // デバイスのチャンネル数が変わった場合は新しいバッファを作る
+                if (buffer != null && buffer.Length == device.ChannelNumber) return buffer;
+                buffer = new byte[device.ChannelNumber];
+                _deviceDmxBufferCache[device] = buffer;
+                return buffer;
+            }
+            var newBuffer = new byte[device.ChannelNumber];
+            _deviceDmxBufferCache[device] = newBuffer;
+            return newBuffer;
         }
     }
 }

--- a/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
+++ b/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
@@ -61,10 +61,10 @@ namespace ArtNet
         {
             var packet = receivedData.Packet;
             var universe = packet.Universe;
-            if (!DmxDictionary.ContainsKey(universe)) DmxDictionary.Add(universe, packet.Dmx);
+            if (!DmxDictionary.ContainsKey(universe)) DmxDictionary.Add(universe, new byte[512]);
             var targetBuffer = DmxDictionary[universe];
-            var copyLength = Math.Min(packet.Dmx.Length, targetBuffer.Length);
-            Buffer.BlockCopy(packet.Dmx, 0, targetBuffer, 0, copyLength);
+            var copyLength = Math.Min((int) packet.Length, targetBuffer.Length);
+            packet.DmxSpan[..copyLength].CopyTo(targetBuffer);
             lock (_updatedUniverses)
             {
                 if (!_queuedUniverses.Add(universe)) return;

--- a/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
+++ b/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
@@ -9,6 +9,7 @@ namespace ArtNet
 {
     public class DmxManager : MonoBehaviour
     {
+        [SerializeField] private ArtNetReceiver _artNetReceiver;
         private readonly Queue<ushort> _updatedUniverses = new();
         private readonly HashSet<ushort> _queuedUniverses = new();
         private Dictionary<ushort, byte[]> DmxDictionary { get; } = new();
@@ -39,6 +40,13 @@ namespace ArtNet
         public void OnEnable()
         {
             DmxDevices = FindDmxDevices();
+            if (_artNetReceiver == null) _artNetReceiver = FindObjectOfType<ArtNetReceiver>();
+            if (_artNetReceiver != null) _artNetReceiver.OnReceivedDmx += ReceivedDmxPacket;
+        }
+
+        public void OnDisable()
+        {
+            if (_artNetReceiver != null) _artNetReceiver.OnReceivedDmx -= ReceivedDmxPacket;
         }
 
         private static Dictionary<ushort, IEnumerable<IDmxDevice>> FindDmxDevices()

--- a/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
+++ b/Assets/ArtNet/Runtime/Scripts/DmxManager.cs
@@ -10,6 +10,7 @@ namespace ArtNet
     public class DmxManager : MonoBehaviour
     {
         private readonly Queue<ushort> _updatedUniverses = new();
+        private readonly HashSet<ushort> _queuedUniverses = new();
         private Dictionary<ushort, byte[]> DmxDictionary { get; } = new();
         public Dictionary<ushort, IEnumerable<IDmxDevice>> DmxDevices { get; private set; }
 
@@ -20,6 +21,7 @@ namespace ArtNet
                 while (0 < _updatedUniverses.Count)
                 {
                     var universe = _updatedUniverses.Dequeue();
+                    _queuedUniverses.Remove(universe);
                     var dmx = DmxDictionary[universe];
                     DmxDevices.TryGetValue(universe, out var devices);
                     if (devices == null) continue;
@@ -65,7 +67,7 @@ namespace ArtNet
             Buffer.BlockCopy(packet.Dmx, 0, targetBuffer, 0, copyLength);
             lock (_updatedUniverses)
             {
-                if (_updatedUniverses.Contains(universe)) return;
+                if (!_queuedUniverses.Add(universe)) return;
                 _updatedUniverses.Enqueue(universe);
             }
         }


### PR DESCRIPTION
  - 受信Art-Netのパケットを Span に変更 
  - ArtNetReceiver で OpCode を先に判定する TryGetOpCode を導入し、パケット生成コストを削減
  - DmxPacketのデータ処理を軽量化
  - DmxManager/IDmxDevice を ReadOnlySpan<byte> 対応に変更し、デバイス更新時の一時配列確保を削減
  - DmxManager に Universe キュー重複防止（HashSet）を追加し、同一Universeの重複処理を抑制
  - ArtNetReceiver に C#イベントを追加し、C#イベント購読時の UnityEvent 呼び出し制御オプションを追加