### PR TITLE
feat: 受信バッファサイズの設定可能にする

### DIFF
--- a/Assets/ArtNet/Editor/ArtNetReceiverInspector.cs
+++ b/Assets/ArtNet/Editor/ArtNetReceiverInspector.cs
@@ -58,6 +58,14 @@ namespace ArtNet.Editor
             GUILayout.Label("Receive Settings", EditorStyles.boldLabel);
             var autoStart = serializedObject.FindProperty("_autoStart");
             if (autoStart != null) EditorGUILayout.PropertyField(autoStart, new GUIContent("Auto Start"));
+            var receiveBufferSizeKb = serializedObject.FindProperty("_receiveBufferSizeKb");
+            if (receiveBufferSizeKb != null)
+            {
+                EditorGUILayout.PropertyField(
+                    receiveBufferSizeKb,
+                    new GUIContent("Receive Buffer Size (KB)", "UDP socket receive buffer size in KB")
+                );
+            }
         }
 
         private void DrawHandlers()

--- a/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
+++ b/Assets/ArtNet/Runtime/Scripts/ArtNetReceiver.cs
@@ -60,8 +60,11 @@ namespace ArtNet
     public class ArtNetReceiver : MonoBehaviour
     {
         public const int ArtNetPort = 6454;
+        private const int MinimumReceiveBufferSizeKb = 1;
+        private const int DefaultReceiveBufferSizeKb = UdpReceiver.DefaultReceiveBufferSizeKB;
 
         [SerializeField] private bool _autoStart = true;
+        [SerializeField, Min(MinimumReceiveBufferSizeKb)] private int _receiveBufferSizeKb = DefaultReceiveBufferSizeKb;
         [SerializeField] private bool _invokeUnityEventWhenCSharpEventSubscribed;
         [SerializeField] private OnReceivedPollEvent _onReceivedPollEvent;
         [SerializeField] private OnReceivedPollReplyEvent _onReceivedPollReplyEvent;
@@ -90,6 +93,7 @@ namespace ArtNet
 
         private void Awake()
         {
+            ApplyReceiveBufferSize();
             UdpReceiver.OnReceivedPacket = OnReceivedPacket;
         }
 
@@ -101,6 +105,17 @@ namespace ArtNet
         private void OnDisable()
         {
             UdpReceiver.StopReceive();
+        }
+
+        private void OnValidate()
+        {
+            _receiveBufferSizeKb = Mathf.Max(MinimumReceiveBufferSizeKb, _receiveBufferSizeKb);
+            ApplyReceiveBufferSize();
+        }
+
+        private void ApplyReceiveBufferSize()
+        {
+            UdpReceiver.ReceiveBufferSizeBytes = _receiveBufferSizeKb * 1024;
         }
 
         private void OnReceivedPacket(byte[] receiveBuffer, int length, EndPoint remoteEp)

--- a/Assets/ArtNet/Runtime/Scripts/UdpReceiver.cs
+++ b/Assets/ArtNet/Runtime/Scripts/UdpReceiver.cs
@@ -9,12 +9,15 @@ namespace ArtNet
 {
     public sealed class UdpReceiver
     {
+        public const int DefaultReceiveBufferSizeKB = 128; // 128 KB
+
         private Socket _socket;
         private CancellationTokenSource _cancellationTokenSource;
         private Task _task;
         private byte[] _receiveBuffer = new byte[1500];
 
         public int Port { get; }
+        public int ReceiveBufferSizeBytes { get; set; } = DefaultReceiveBufferSizeKB * 1024;
         public bool IsRunning => _task is { IsCanceled: false, IsCompleted: false };
 
         public ReceivedPacketEventHandler OnReceivedPacket = (_, _, _) => { };
@@ -45,6 +48,7 @@ namespace ArtNet
             {
                 _socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                 _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                _socket.ReceiveBufferSize = Math.Max(1024, ReceiveBufferSizeBytes);
                 _socket.Bind(new IPEndPoint(IPAddress.Any, Port));
 
                 _cancellationTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
- ArtNetの受信バッファサイズを設定可能にする(デフォルト128KB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable UDP receive buffer size setting for the ArtNet receiver (default 128 KB) in the inspector, enabling network performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->